### PR TITLE
Add computed goto feature to EIR

### DIFF
--- a/gen.c
+++ b/gen.c
@@ -1076,13 +1076,13 @@ static void emit_assign(Node *node) {
 
 static void emit_label_addr(Node *node) {
     SAVE;
-    emit("mov $%s, #rax", node->newlabel);
+    emit("mov A, %s", node->newlabel);
 }
 
 static void emit_computed_goto(Node *node) {
     SAVE;
     emit_expr(node->operand);
-    emit("jmp *#rax");
+    emit("jmp A");
 }
 
 static void emit_expr(Node *node) {


### PR DESCRIPTION
The computed goto feature (and the "Labels as Values" feature) allows the address of `goto` labels to be stored in `void*` pointers, and allows jumping to them by writing code such as `goto *ptr;`, as described [here](https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html).

Although this is a non-standard feature, the original 8cc implements this through `emit_label_addr` and `emit_computed_goto`. However, these functions were left as is from the original 8cc code and also didn't have any tests, being left as unimplemented. Although 8cc finishes without errors when using this syntax, the compiled EIR causes an error when compiled by ELC. (8cc emits instructions unknown to ELC.)

This pull request fixes these functions and adds the computed goto feature to EIR (ELVM).

I will be making another pull request in the ELVM repository that add a test for this feature. I've tested this feature using ELVM's test system. Please see the ELVM pull request for details.